### PR TITLE
Add OTP 24 support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,6 +27,11 @@ jobs:
       matrix:
         elixir: [1.10.4, 1.11.4, 1.12.1]
         otp: [22.3, 23.3, 24.0]
+        exclude:
+          - otp: 24.0
+            elixir: 1.10.4
+          - otp: 24.0
+            elixir: 1.11.4
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ jobs:
 
     name: Build and test
     runs-on: ubuntu-latest
-    
+
     services:
       redis:
         image: redis
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         elixir: [1.10.4, 1.11.4, 1.12.1]
-        otp: [22.3, 23.3]
+        otp: [22.3, 23.3, 24.0]
 
     steps:
     - uses: actions/checkout@v2
@@ -59,5 +59,5 @@ jobs:
     - name: Run tests
       run: mix test
       env:
-        REDIS_HOST: localhost 
+        REDIS_HOST: localhost
         REDIS_PORT: 6379

--- a/lib/rediscovery/listener.ex
+++ b/lib/rediscovery/listener.ex
@@ -2,9 +2,10 @@ defmodule Rediscovery.Listener do
   @callback list() :: [node()]
   @callback add(list({node(), map()})) :: any()
   @callback remove(list(node())) :: any()
+  alias Rediscovery.ProcessGroup
 
   def change(nodes) when is_list(nodes) do
-    case :pg2.get_local_members(__MODULE__) do
+    case ProcessGroup.get_local_members(__MODULE__) do
       {:error, {:no_such_group, _}} -> :ok
       pids -> Enum.each(pids, &GenServer.cast(&1, {:change, nodes}))
     end
@@ -22,8 +23,8 @@ defmodule Rediscovery.Listener do
 
       @impl true
       def init(nil) do
-        :pg2.create(unquote(__MODULE__))
-        :ok = :pg2.join(unquote(__MODULE__), self())
+        ProcessGroup.create(unquote(__MODULE__))
+        :ok = ProcessGroup.join(unquote(__MODULE__), self())
         {:ok, nil, {:continue, :setup}}
       end
 

--- a/lib/rediscovery/listener.ex
+++ b/lib/rediscovery/listener.ex
@@ -23,6 +23,7 @@ defmodule Rediscovery.Listener do
 
       @impl true
       def init(nil) do
+        :ok = ProcessGroup.start()
         ProcessGroup.create(unquote(__MODULE__))
         :ok = ProcessGroup.join(unquote(__MODULE__), self())
         {:ok, nil, {:continue, :setup}}

--- a/lib/rediscovery/process_group.ex
+++ b/lib/rediscovery/process_group.ex
@@ -7,10 +7,24 @@ defmodule Rediscovery.ProcessGroup do
   @otp_version :erlang.system_info(:otp_release) |> to_string() |> String.to_integer()
 
   if @otp_version >= 23 do
+    def start do
+      case :pg.start_link() do
+        {:ok, _} ->
+          :ok
+
+        {:error, {:already_started, _}} ->
+          :ok
+
+        error ->
+          error
+      end
+    end
+
     def create(name), do: :pg.start(name) |> elem(0)
     def get_local_members(name), do: :pg.get_local_members(name)
     def join(group_name, pid), do: :pg.join(group_name, pid)
   else
+    def start, do: :ok
     def create(name), do: :pg2.create(name)
     def get_local_members(name), do: :pg2.get_local_members(name)
     def join(group_name, pid), do: :pg2.join(group_name, pid)

--- a/lib/rediscovery/process_group.ex
+++ b/lib/rediscovery/process_group.ex
@@ -1,0 +1,18 @@
+defmodule Rediscovery.ProcessGroup do
+  @moduledoc """
+  Wrapper for Erlang process group modules.
+  pg2 was removed in OTP 24 and replaced with pg which was introduced in OTP 23.
+  """
+
+  @otp_version :erlang.system_info(:otp_release) |> to_string() |> String.to_integer()
+
+  if @otp_version >= 23 do
+    def create(name), do: :pg.start(name) |> elem(0)
+    def get_local_members(name), do: :pg.get_local_members(name)
+    def join(group_name, pid), do: :pg.join(group_name, pid)
+  else
+    def create(name), do: :pg2.create(name)
+    def get_local_members(name), do: :pg2.get_local_members(name)
+    def join(group_name, pid), do: :pg2.join(group_name, pid)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Rediscovery.MixProject do
   use Mix.Project
 
   @name "Rediscovery"
-  @version "0.4.0"
+  @version "0.5.0"
   @repo_url "https://github.com/jeffutter/rediscovery"
 
   def project do

--- a/test/rediscovery/listener_test.exs
+++ b/test/rediscovery/listener_test.exs
@@ -44,7 +44,7 @@ defmodule Rediscovery.ListenerTest do
     assert_receive {:remove, [:fake1@node]}
   end
 
-  test "Receives events cast from :pg2" do
+  test "Receives events cast from :pg" do
     :persistent_term.put({FakeListener, :test_pid}, self())
     on_exit(fn -> :persistent_term.erase({FakeListener, :test_pid}) end)
     start_supervised(Rediscovery.State)

--- a/test/rediscovery/state_test.exs
+++ b/test/rediscovery/state_test.exs
@@ -11,6 +11,7 @@ defmodule Rediscovery.StateTest do
     end
 
     def init(pid) do
+      :ok = ProcessGroup.start()
       ProcessGroup.create(Rediscovery.Listener)
       :ok = ProcessGroup.join(Rediscovery.Listener, self())
       {:ok, pid}

--- a/test/rediscovery/state_test.exs
+++ b/test/rediscovery/state_test.exs
@@ -1,7 +1,7 @@
 defmodule Rediscovery.StateTest do
   use ExUnit.Case, async: false
 
-  alias Rediscovery.State
+  alias Rediscovery.{ProcessGroup, State}
 
   defmodule FakeListener do
     use GenServer
@@ -11,8 +11,8 @@ defmodule Rediscovery.StateTest do
     end
 
     def init(pid) do
-      :pg2.create(Rediscovery.Listener)
-      :ok = :pg2.join(Rediscovery.Listener, self())
+      ProcessGroup.create(Rediscovery.Listener)
+      :ok = ProcessGroup.join(Rediscovery.Listener, self())
       {:ok, pid}
     end
 


### PR DESCRIPTION
The `:pg2` module was removed in OTP 24 and replaced with the `:pg` module introduced in OTP 23. This PR _should_ chose the correct module depending on the OTP version and maintain backward compatibility with older OTP versions.